### PR TITLE
Fix systemd target cyclic dependency

### DIFF
--- a/config/beamline_status_logger.target
+++ b/config/beamline_status_logger.target
@@ -1,6 +1,6 @@
 [Unit]
 Description=Log beamline attributes to a database
-Requires=multi-user.target
+After=network.target
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
It seems strange that the same target can be listed in `Requires` (which is a stronger version of `Wants`) and `WantedBy` at the same time. Listening `After=network.target` seems to be common for services that are `WantedBy=multi-user.target`.

The CI failure is unrelated. 