### PR TITLE
Remove install dependency on imageio

### DIFF
--- a/.ci/debian9/Dockerfile
+++ b/.ci/debian9/Dockerfile
@@ -49,7 +49,7 @@ RUN apt-get update && apt-get install -y \
         quilt \
         adduser \
         git-buildpackage \
-    && pip3 install influxdb
+    && pip3 install influxdb 'imageio<2.10'  # for compatibility with pillow 4.0
 
 
 # more info at https://docs.docker.com/config/containers/multi-service_container/

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
     - sleep 3
 
 script:
+    - docker-compose exec -T tango-test python3 -m pip install -r dev-requirements.txt
     - docker-compose exec -T tango-test python3 -m pip install .
     - docker-compose exec -T tango-test python3 -m flake8
     - docker-compose exec -T tango-test python3 -m pytest --cov=BeamlineStatusLogger --cov-report xml:coverage.xml

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,4 @@
+pytest
+pytest-cov
+pytest-mock
+imageio

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ setup(name="BeamlineStatusLogger",
           "scipy",
           "scikit-image",
           "pytz",
-          "imageio"
       ],
       zip_safe=False,
       data_files=[


### PR DESCRIPTION
Recent imageio versions now require a pillow version that is not
available on Debian 9. As that package is only needed for tests,
remove it from install dependencies.