### PR TITLE
Ignore connection errors for sources at startup

### DIFF
--- a/BeamlineStatusLogger/sources.py
+++ b/BeamlineStatusLogger/sources.py
@@ -57,8 +57,6 @@ class TangoDeviceAttributeSource:
         self.attribute_name = attribute_name
         # TODO: Should a possible exception be wrapped?
         self.device = tango.DeviceProxy(device_name)
-        # Test if attribute exists
-        self.device.attribute_query(attribute_name)
         self.metadata = metadata
         if "quality" in self.metadata:
             raise ValueError("The metadata entry 'quality' is reserved for the"
@@ -158,8 +156,6 @@ class TINECameraSource:
             raise tine_import_err
         self.device_address = device_address
         self.property_name = property_name
-        # Test if device and property exists
-        tine.get(self.device_address, self.property_name)
         self.metadata = metadata
         if "status" in self.metadata:
             raise ValueError("The metadata entry 'status' is reserved for the"

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -29,8 +29,9 @@ class TestTangoDeviceAttributeSource:
     def test_init_wrong_attribute(self):
         device_name = "sys/tg_test/1"
         attribute_name = "float_scala"
-        with pytest.raises(tango.DevFailed):
-            TangoDeviceAttributeSource(device_name, attribute_name)
+        source = TangoDeviceAttributeSource(device_name, attribute_name)
+        data = source.read()
+        assert data.failure
 
     def test_init_metadata_contains_quality(self):
         device_name = "sys/tg_test/1"
@@ -201,8 +202,9 @@ class TestTINECameraSource:
     def test_init_failure(self):
         device_address = "/CONTEXT/server/other_device"
         property_name = "frame"
-        with pytest.raises(RuntimeError):
-            TINECameraSource(device_address, property_name)
+        source = TINECameraSource(device_address, property_name)
+        data = source.read()
+        assert data.failure
 
     def test_init_metadata_contains_status(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
Instead, keep running and log the errors until the source comes online.