### PR TITLE
Implement text file sink

### DIFF
--- a/BeamlineStatusLogger/sinks.py
+++ b/BeamlineStatusLogger/sinks.py
@@ -1,8 +1,10 @@
+import datetime
 from pathlib import Path
 from influxdb import InfluxDBClient
 from collections.abc import Mapping
 import os
 import numpy as np
+from pytz import timezone
 
 
 def filter_nones(dic):
@@ -88,6 +90,17 @@ class InfluxDBSink:
         }
 
 
+def column_width_from_timespec(timespec):
+    timestamp = datetime.datetime(
+        2000, 1, 1, 12, 0, 0, 0, tzinfo=timezone("Europe/Berlin"))
+    return len(timestamp.isoformat(timespec=timespec))
+
+
+def column_width_from_value_format(value_format):
+    value = 1/3
+    return len(f"{value:{value_format}}")
+
+
 class TextFileSink:
     """Write log data to a text file.
 
@@ -125,7 +138,8 @@ class TextFileSink:
         path,
         sep="\t",
         timespec="milliseconds",
-        value_format="foo",
+        # TODO: There should be separate string and number formats
+        value_format="<12.10g",
         create_dirs=True,
         metadata=None
     ):
@@ -134,6 +148,7 @@ class TextFileSink:
         self.fieldnames = None
         self.sep = sep
         self.timespec = timespec
+        self.timestamp_width = column_width_from_timespec(timespec)
         self.value_format = value_format
         if metadata is None:
             metadata = {}
@@ -219,9 +234,11 @@ class TextFileSink:
         if tags:
             for key, value in tags.items():
                 header += f"# {key}: {value}\n"
-        # TODO: Determine lengths from timespec and value_format
-        header += f"{'timestamp':<{len('2000-01-01T00:00:00.000+01:00')}}\t"
-        header += "\t".join(f"{field:<6}" for field in fieldnames)
+
+        value_width = column_width_from_value_format(self.value_format)
+        header += f"{'timestamp':<{self.timestamp_width}}\t"
+        header += "\t".join(
+            f"{field:<{value_width}}" for field in fieldnames)
         header += "\terror\n"
         return header
 
@@ -236,13 +253,18 @@ class TextFileSink:
             else:
                 fields = {"value": data.value}
 
-        t_len = len('2000-01-01T00:00:00.000+01:00')
-        row = f"{data.timestamp.isoformat(timespec=self.timespec):<{t_len}}\t"
+        w = self.timestamp_width
+        t = data.timestamp.isoformat(timespec=self.timespec)
+        row = f"{t:<{w}}\t"
         row += "\t".join(
-            str(none_to_nan(fields[key])) if key in fields else "nan"
+            f"{none_to_nan(fields[key]):{self.value_format}}"
+            if key in fields else f"{np.nan:{self.value_format}}"
             for key in self.fieldnames)
         if error:
             row += "\t" + error
+        else:
+            # Remove unnecessary whitespace at the end of the line
+            row = row.rstrip()
         row += "\n"
         return row
 

--- a/BeamlineStatusLogger/sinks.py
+++ b/BeamlineStatusLogger/sinks.py
@@ -212,7 +212,9 @@ class TextFileSink:
 
     def _format_header(self, fieldnames, metadata):
         header = ""
-        tags = metadata
+        # The quality tag doesn't make sense in the header
+        tags = {
+            key: value for key, value in metadata.items() if key != "quality"}
         tags.update(self.metadata)
         if tags:
             for key, value in tags.items():

--- a/BeamlineStatusLogger/sinks.py
+++ b/BeamlineStatusLogger/sinks.py
@@ -35,7 +35,7 @@ class InfluxDBSink:
     port : string or int
         InfluxDB port. If not given, the environment variable INFLUXDB_PORT is
         used instead
-    create_db : Booolean
+    create_db : Boolean
         If True, the database is created if it does not already exist
     metadata : mapping
         These entries are appended as the tags to each point
@@ -114,7 +114,7 @@ class TextFileSink:
         (default: "milliseconds")
     value_format : string
         Format used for all values
-    create_dirs : Booolean
+    create_dirs : Boolean
         If True, all parent directories are created if not already existing
         (Default: True)
     metadata : mapping

--- a/tests/test_sinks.py
+++ b/tests/test_sinks.py
@@ -290,3 +290,18 @@ class TestTextFileSink:
         data = Data(time, {"foo": 1})
         with pytest.raises(ValueError, match="invalid"):
             text_file_sink.write(data)
+
+    def test_filter_quality_tag_from_header(self, text_file_sink):
+        time = datetime(2018, 8, 15, 17, 37, 39, 660510)
+        data = Data(
+            time, 1,
+            metadata={"attribute": "position", "quality": "ATTR_VALID"})
+        success = text_file_sink.write(data)
+        assert success
+        assert text_file_sink.path.exists()
+        assert text_file_sink.path.read_text() == (
+            "# attribute: position\n"
+            "# id: 1234\n"
+            "timestamp                    	value 	error\n"
+            "2018-08-15T17:37:39.660      	1\n"
+        )

--- a/tests/test_sinks.py
+++ b/tests/test_sinks.py
@@ -1,4 +1,4 @@
-from BeamlineStatusLogger.sinks import InfluxDBSink, filter_nones
+from BeamlineStatusLogger.sinks import InfluxDBSink, TextFileSink, filter_nones
 from BeamlineStatusLogger.sources import Data
 from influxdb import InfluxDBClient
 from datetime import datetime
@@ -149,3 +149,144 @@ class TestInfluxDBSink:
         assert len(rows) == 1
         assert rows[0]["time"] == '2018-08-15T17:37:39.524288Z'
         assert rows[0]["error"] == "msg"
+
+
+@pytest.fixture
+def text_file_sink(tmp_path):
+    filename = tmp_path / "out.dat"
+    return TextFileSink(filename, metadata={"id": 1234})
+
+
+class TestTextFileSink:
+    def test_init_success(self, tmp_path):
+        filename = tmp_path / "out.dat"
+        sink = TextFileSink(filename)
+        assert sink.path == filename
+        assert sink.file is None
+        assert sink.metadata == {}
+
+    def test_init_create_parent_dirs(self, tmp_path):
+        filename = tmp_path / "does_not_exist" / "out.dat"
+        TextFileSink(filename)
+        assert filename.parent.exists()
+
+    def test_init_do_not_create_parent_dirs(self, tmp_path):
+        filename = tmp_path / "does_not_exist" / "out.dat"
+        TextFileSink(filename, create_dirs=False)
+        assert not filename.parent.exists()
+
+    def test_write_number(self, text_file_sink):
+        time = datetime(2018, 8, 15, 17, 37, 39, 660510)
+        data = Data(time, 1, metadata={"attribute": "position"})
+        success = text_file_sink.write(data)
+        assert success
+        assert text_file_sink.path.exists()
+        assert text_file_sink.path.read_text() == (
+            "# attribute: position\n"
+            "# id: 1234\n"
+            "timestamp                    	value 	error\n"
+            "2018-08-15T17:37:39.660      	1\n"
+        )
+
+    def test_write_dict(self, text_file_sink):
+        time = datetime(2018, 8, 15, 17, 37, 39, 660510)
+        data = Data(time, {"value1": 1, "value2": 2, "value": None},
+                    metadata={"attribute": "position"})
+        success = text_file_sink.write(data)
+        assert success
+        assert text_file_sink.path.exists()
+        assert text_file_sink.path.read_text() == (
+            "# attribute: position\n"
+            "# id: 1234\n"
+            "timestamp                    	value 	value1	value2	error\n"
+            "2018-08-15T17:37:39.660      	nan	1	2\n"
+        )
+
+    def test_write_error_first_data_point(self, text_file_sink):
+        time = datetime(2018, 8, 15, 17, 37, 39, 660510)
+        data = Data(time, None, failure=RuntimeError("msg"),
+                    metadata={"attribute": "position"})
+        success = text_file_sink.write(data)
+        assert not success
+        assert text_file_sink.path.exists()
+        assert text_file_sink.path.read_text() == ""
+
+    def test_write_error_second_data_point(self, text_file_sink):
+        time = datetime(2018, 8, 15, 17, 37, 39, 660510)
+        data = Data(time, 1, metadata={"attribute": "position"})
+        res = text_file_sink.write(data)
+        assert res
+        data = Data(time, None, failure=RuntimeError("msg"),
+                    metadata={"attribute": "position"})
+        res = text_file_sink.write(data)
+        assert not res
+        assert text_file_sink.path.exists()
+        assert text_file_sink.path.read_text() == (
+            "# attribute: position\n"
+            "# id: 1234\n"
+            "timestamp                    	value 	error\n"
+            "2018-08-15T17:37:39.660      	1\n"
+            "2018-08-15T17:37:39.660      	nan\tRuntimeError\n"
+        )
+
+    @pytest.mark.parametrize("value", [None, {"value": None}])
+    def test_write_none(self, text_file_sink, value):
+        # Write header so that writing a None value succeeds
+        text_file_sink.path.write_text(
+            "timestamp                    	value 	error\n")
+        time = datetime(2018, 8, 15, 17, 37, 39, 660510)
+        data = Data(time, value, metadata={"attribute": "position"})
+        success = text_file_sink.write(data)
+        assert not success
+        assert text_file_sink.path.exists()
+        assert text_file_sink.path.read_text() == (
+            "timestamp                    	value 	error\n"
+            "2018-08-15T17:37:39.660      	nan\n"
+        )
+
+    def test_write_data_points_mismatching_fieldnames(self, text_file_sink):
+        time = datetime(2018, 8, 15, 17, 37, 39, 660510)
+        data = Data(time, {"foo": 1})
+        success = text_file_sink.write(data)
+        assert success
+        time = datetime(2018, 8, 15, 17, 37, 44, 660510)
+        data = Data(time, {"bar": 1})
+        with pytest.raises(ValueError, match="previously unseen"):
+            text_file_sink.write(data)
+
+    def test_write_data_points_mismatching_header(self, text_file_sink):
+        text_file_sink.path.write_text(
+            "timestamp              	foo 	error\n")
+        time = datetime(2018, 8, 15, 17, 37, 44, 660510)
+        data = Data(time, {"bar": 1})
+        with pytest.raises(ValueError, match="previously unseen"):
+            text_file_sink.write(data)
+
+    def test_read_header_from_file(self, text_file_sink):
+        text_file_sink.path.write_text(
+            "# some: 1\n"
+            "# metadata: True\n"
+            "timestamp                    	foo 	error\n"
+            "2018-08-15T17:37:39.660      	1\n")
+        time = datetime(2018, 8, 15, 17, 37, 44, 660510)
+        data = Data(time, None)
+        success = text_file_sink.write(data)
+        assert not success
+        assert text_file_sink.path.read_text() == (
+            "# some: 1\n"
+            "# metadata: True\n"
+            "timestamp                    	foo 	error\n"
+            "2018-08-15T17:37:39.660      	1\n"
+            "2018-08-15T17:37:44.660      	nan\n"
+        )
+
+    def test_read_header_from_file_invalid(self, text_file_sink):
+        text_file_sink.path.write_text(
+            "# some: 1\n"
+            "# metadata: True\n"
+            "foo                          	bar 	error\n"
+            "2018-08-15T17:37:39.660      	1\n")
+        time = datetime(2018, 8, 15, 17, 37, 44, 660510)
+        data = Data(time, {"foo": 1})
+        with pytest.raises(ValueError, match="invalid"):
+            text_file_sink.write(data)

--- a/tests/test_sinks.py
+++ b/tests/test_sinks.py
@@ -184,7 +184,7 @@ class TestTextFileSink:
         assert text_file_sink.path.read_text() == (
             "# attribute: position\n"
             "# id: 1234\n"
-            "timestamp                    	value 	error\n"
+            "timestamp                    	value       	error\n"
             "2018-08-15T17:37:39.660      	1\n"
         )
 
@@ -198,8 +198,8 @@ class TestTextFileSink:
         assert text_file_sink.path.read_text() == (
             "# attribute: position\n"
             "# id: 1234\n"
-            "timestamp                    	value 	value1	value2	error\n"
-            "2018-08-15T17:37:39.660      	nan	1	2\n"
+            "timestamp                    	value       	value1      	value2      	error\n"
+            "2018-08-15T17:37:39.660      	nan         	1           	2\n"
         )
 
     def test_write_error_first_data_point(self, text_file_sink):
@@ -224,23 +224,23 @@ class TestTextFileSink:
         assert text_file_sink.path.read_text() == (
             "# attribute: position\n"
             "# id: 1234\n"
-            "timestamp                    	value 	error\n"
+            "timestamp                    	value       	error\n"
             "2018-08-15T17:37:39.660      	1\n"
-            "2018-08-15T17:37:39.660      	nan\tRuntimeError\n"
+            "2018-08-15T17:37:39.660      	nan         \tRuntimeError\n"
         )
 
     @pytest.mark.parametrize("value", [None, {"value": None}])
     def test_write_none(self, text_file_sink, value):
         # Write header so that writing a None value succeeds
         text_file_sink.path.write_text(
-            "timestamp                    	value 	error\n")
+            "timestamp                    	value       	error\n")
         time = datetime(2018, 8, 15, 17, 37, 39, 660510)
         data = Data(time, value, metadata={"attribute": "position"})
         success = text_file_sink.write(data)
         assert not success
         assert text_file_sink.path.exists()
         assert text_file_sink.path.read_text() == (
-            "timestamp                    	value 	error\n"
+            "timestamp                    	value       	error\n"
             "2018-08-15T17:37:39.660      	nan\n"
         )
 
@@ -302,6 +302,6 @@ class TestTextFileSink:
         assert text_file_sink.path.read_text() == (
             "# attribute: position\n"
             "# id: 1234\n"
-            "timestamp                    	value 	error\n"
+            "timestamp                    	value       	error\n"
             "2018-08-15T17:37:39.660      	1\n"
         )


### PR DESCRIPTION
Allows logging data points to a text file. Currently, only number values are allowed. In case of errors, only the error type is logged in an extra column.